### PR TITLE
Load the SSH Credentials settings from the disk if not initialized.

### DIFF
--- a/LibGit-Core.package/LGitRemote.class/class/keyFilePrivatePath.st
+++ b/LibGit-Core.package/LGitRemote.class/class/keyFilePrivatePath.st
@@ -2,4 +2,7 @@ accessing-credentials
 keyFilePrivatePath
 	^ self credentials
 		at: #keyFilePrivatePath
-		ifAbsentPut: [ UIManager default request: 'Path to your private key file (/home/foo/.ssh/key)?' ]
+		ifAbsentPut: [ | value |
+			value := (SystemSettingsPersistence default nodeNamed: #'keyFilePrivatePath') storedValue.
+			value ifNil: [ 
+				UIManager default request: 'Path to your private key file (/home/foo/.ssh/key)?' ] ]

--- a/LibGit-Core.package/LGitRemote.class/class/keyFilePublicPath.st
+++ b/LibGit-Core.package/LGitRemote.class/class/keyFilePublicPath.st
@@ -2,4 +2,7 @@ accessing-credentials
 keyFilePublicPath
 	^ self credentials
 		at: #keyFilePublicPath
-		ifAbsentPut: [ UIManager default request: 'Path to your public key file (/home/foo/.ssh/key.pub)?' ]
+		ifAbsentPut: [  | value |
+			value := (SystemSettingsPersistence default nodeNamed: #'keyFilePublicPath') storedValue.
+			value ifNil: [ 
+				UIManager default request: 'Path to your public key file (/home/foo/.ssh/key.pub)?' ] ]

--- a/LibGit-Core.package/LGitRemote.class/class/keyPassPhrase.st
+++ b/LibGit-Core.package/LGitRemote.class/class/keyPassPhrase.st
@@ -2,4 +2,7 @@ accessing-credentials
 keyPassPhrase
 	^ self credentials
 		at: #keyPassPhrase
-		ifAbsentPut: [ UIManager default request: 'Passphrase of your private key file?' ]
+		ifAbsentPut: [  | value |
+			value := (SystemSettingsPersistence default nodeNamed: #'keyPassPhrase') storedValue.
+			value ifNil: [ 
+				UIManager default request: 'Passphrase of your private key file?' ] ]

--- a/LibGit-Core.package/LGitRemote.class/class/usernameSsh.st
+++ b/LibGit-Core.package/LGitRemote.class/class/usernameSsh.st
@@ -2,7 +2,9 @@ accessing-credentials
 usernameSsh
 	^ self credentials
 		at: #usernameSsh
-		ifAbsentPut: [ 
-			UIManager default 
-				request: 'What''s your username for SSH (probably "git")?'
-				initialAnswer: 'git' ]
+		ifAbsentPut: [  | value |
+			value := (SystemSettingsPersistence default nodeNamed: #'usernameSsh') storedValue.
+			value ifNil: [ 
+				UIManager default 
+					request: 'What''s your username for SSH (probably "git")?'
+					initialAnswer: 'git' ] ]


### PR DESCRIPTION
If SSH Credentials are not set in an image, it looks for saved values on the disk. If there is nothing, then it asks a user.

Someone can save the setting in the Settings Browser.