### PR TITLE
20744 Unused temp var in LGitReference>>pushUpstream

### DIFF
--- a/LibGit-Core.package/LGitReference.class/instance/pushUpstream.st
+++ b/LibGit-Core.package/LGitReference.class/instance/pushUpstream.st
@@ -1,6 +1,6 @@
 accessing
 pushUpstream
-	 
+	  
 	^ self repository config 
 		getString: 'remote.pushDefault'
 		ifPresent: [ :pushRemoteName |

--- a/LibGit-Core.package/LGitReference.class/instance/pushUpstream.st
+++ b/LibGit-Core.package/LGitReference.class/instance/pushUpstream.st
@@ -1,6 +1,6 @@
 accessing
 pushUpstream
-	| pushRemote | 
+	 
 	^ self repository config 
 		getString: 'remote.pushDefault'
 		ifPresent: [ :pushRemoteName |


### PR DESCRIPTION
fix unused temp in LGitReference>>pushUpstream

https://pharo.fogbugz.com/f/cases/20744/Unused-temp-var-in-LGitReference-pushUpstream