### PR TITLE
Library Locations should be Absolute

### DIFF
--- a/LibGit-Core.package/LGitLibrary.class/instance/macModuleName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/macModuleName.st
@@ -4,6 +4,6 @@ macModuleName
 	pluginDir := Smalltalk vm binary parent / 'Plugins'.
 	#('libgit2.dylib' 'libgit2.0.dylib')
 		detect: [ :each | (pluginDir / each) exists ] 
-		ifFound: [ :libName | ^ libName ].
+		ifFound: [ :libName | ^ (pluginDir / libName) fullName  ].
 
 	self error: 'Module not found.'

--- a/LibGit-Core.package/LGitLibrary.class/instance/unixModuleName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/unixModuleName.st
@@ -4,6 +4,6 @@ unixModuleName
 	pluginDir := Smalltalk vm binary parent.
 	#('libgit2.so' 'libgit2.so.0')
 		detect: [ :each | (pluginDir / each) exists ] 
-		ifFound: [ :libName | ^ libName ].
+		ifFound: [ :libName | ^ (pluginDir / libName) fullName ].
 
 	self error: 'Module not found.'


### PR DESCRIPTION
The library location in Unix and OSX should be absolute, if not it is possible to load other DLL than the intended one.

If the other DLL is in the path before the required, it is loaded first. It produces incompatibilities with the version of the mapped structures.