### PR TITLE
Implementation of diff similarity (e.g. file renames)

### DIFF
--- a/LibGit-Core.package/LGitDiff.class/instance/deltas.st
+++ b/LibGit-Core.package/LGitDiff.class/instance/deltas.st
@@ -1,0 +1,6 @@
+operations
+deltas
+	^ Array
+		new: self numberOfDeltas
+		streamContents: [ :stream |
+			self deltasDo: [ :delta | stream nextPut: delta ] ]

--- a/LibGit-Core.package/LGitDiff.class/instance/deltasDo..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/deltasDo..st
@@ -1,0 +1,3 @@
+operations
+deltasDo: aBlock
+	^ 1 to: self numberOfDeltas do: aBlock

--- a/LibGit-Core.package/LGitDiff.class/instance/deltasDo..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/deltasDo..st
@@ -1,3 +1,3 @@
 operations
 deltasDo: aBlock
-	^ 1 to: self numberOfDeltas do: aBlock
+	^ 1 to: self numberOfDeltas do: [ :index | aBlock value: (self deltaAt: index) ]

--- a/LibGit-Core.package/LGitDiff.class/instance/diffFindSimilar..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diffFindSimilar..st
@@ -1,0 +1,6 @@
+operations
+diffFindSimilar: options
+	^ self withReturnHandlerDo: [
+		self
+			diff_find_similar: self
+			diff_find_options: options ]

--- a/LibGit-Core.package/LGitDiff.class/instance/diffFindSimilar.st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diffFindSimilar.st
@@ -1,0 +1,3 @@
+operations
+diffFindSimilar
+	^ self diffFindSimilar: LGitDiffFindOptions defaults

--- a/LibGit-Core.package/LGitDiff.class/instance/diff_find_similar.diff_find_options..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diff_find_similar.diff_find_options..st
@@ -1,0 +1,4 @@
+libgit-calls
+diff_find_similar: diff diff_find_options: options
+	
+	^ self call: #(LGitReturnCodeEnum git_diff_find_similar #(self, LGitDiffFindOptions *options)) options: #()

--- a/LibGit-Core.package/LGitDiffFindOptions.class/instance/flags..st
+++ b/LibGit-Core.package/LGitDiffFindOptions.class/instance/flags..st
@@ -1,0 +1,3 @@
+accessing structure variables
+flags: diffFlags
+	self prim_flags: diffFlags

--- a/LibGit-Core.package/LGitDiffFindOptions.class/instance/prim_flags..st
+++ b/LibGit-Core.package/LGitDiffFindOptions.class/instance/prim_flags..st
@@ -1,4 +1,4 @@
 libgit-fields
-prim_flags: anObject
+prim_flags: diffFindTypeEnum
 	"This method was automatically generated"
-	handle unsignedLongAt: OFFSET_PRIM_FLAGS put: anObject
+	handle unsignedLongAt: OFFSET_PRIM_FLAGS put: diffFindTypeEnum value

--- a/LibGit-Core.package/LGitDiffFindOptions.class/instance/prim_flags.st
+++ b/LibGit-Core.package/LGitDiffFindOptions.class/instance/prim_flags.st
@@ -1,4 +1,4 @@
 libgit-fields
 prim_flags
 	"This method was automatically generated"
-	^handle unsignedLongAt: OFFSET_PRIM_FLAGS
+	^ LGitDiffFindTypeEnum fromInteger: (handle unsignedLongAt: OFFSET_PRIM_FLAGS)


### PR DESCRIPTION
Pair programmed with @theseion at ESUG.

Tests are missing... they crash my Pharo 8 so cannot run/extend them, but I detail one possible way to test this PR with an example:

1. Load Ring2 with:
~~~
Metacello new
  baseline: 'Ring2';
  repository: 'github://pavel-krivanek/Ring2/src';
  load.
~~~

2. Evaluate and inspect the outputs of:
~~~
iceRepo := IceRepository registry detect: [ :each | each name = 'Ring2' ].
repo := iceRepo repositoryHandle.

theCommit := (repo revparse: '40ccf34d99ea9c2f0a647631e2b92effec70f3de') object.
itsParent := theCommit parents first.

diff := theCommit tree diffTo: itsParent tree.
options := LGitDiffFindOptions defaults
	flags: LGitDiffFindTypeEnum git_diff_find_renames;
	yourself.
diff diffFindSimilar: options.

deltas := diff deltas.

deltasInfo := deltas collect: [ :each | {each status symbol. each oldFile path. each newFile path } ].
deltasGrouped := deltasInfo groupedBy: #first.
deltasRenamed := deltasGrouped at: #git_delta_renamed.
~~~

It wouldn't be necessary to load the Ring2 code into the image or to access the LGitRepository via Iceberg, but it's the example snippet I have and it worked well in a recent Pharo 8.

