### PR TITLE
LGitId>>hexString improvements

### DIFF
--- a/LibGit-Core.package/LGitId.class/instance/hexString.st
+++ b/LibGit-Core.package/LGitId.class/instance/hexString.st
@@ -1,10 +1,12 @@
 printing
 hexString
-	| string |
+	"Answer a hex string representation of the receiver"
+	| buffer |
+
 	self isExternal
 		ifFalse: [ ^ handle hex ].
-	string := String new: 40.
-	string pin.
-	self oid_fmt: string id: self.
-	string unpin.
-	^ string
+	buffer := ByteArray new: 40.
+	buffer pin.
+	self oid_fmt: buffer size: 40 id: self.
+	buffer unpin.
+	^ buffer asString

--- a/LibGit-Core.package/LGitId.class/instance/oid_fmt.id..st
+++ b/LibGit-Core.package/LGitId.class/instance/oid_fmt.id..st
@@ -1,3 +1,0 @@
-libgit-calls
-oid_fmt: out id:  objectId
-	^self call: #(void git_oid_fmt(void *out, LGitId * self)) options: #(  )

--- a/LibGit-Core.package/LGitId.class/instance/oid_fmt.size.id..st
+++ b/LibGit-Core.package/LGitId.class/instance/oid_fmt.size.id..st
@@ -1,0 +1,5 @@
+libgit-calls
+oid_fmt: aByteArray size: anInteger id: objectId
+	"Format a git_oid into a partial hex string"
+
+	^self call: #(void git_oid_nfmt(void *aByteArray, int anInteger, LGitId * self)) options: #(  )


### PR DESCRIPTION
This PR proposes two improvements to LGitId>>hexString:

1. Pass a ByteArray as the return buffer instead of String in #hexString.
Using a String works in Squeak FFI as the result is guaranteed to be ascii, but it is bad practice in general.
In Threaded FFI Strings are utf8 encoded and then passed in a buffer that is discarded after the call completes, i.e. they can't be used to return values (which is good since the decoding hasn't been done).
2. Use git_oid_nfmt() instead of git_oid_fmt().  The latter is suspectable to buffer overruns, which will corrupt object memory.As implied in the first point above, this change is a pre-requisite for using LibGit with threaded FFI due to the improvement in string handling.