### PR TITLE
use-libraryfinder

### DIFF
--- a/LibGit-Core.package/LGitLibrary.class/instance/macLibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/macLibraryName.st
@@ -1,0 +1,4 @@
+accessing platform
+macLibraryName
+
+	^ FFIMacLibraryFinder findAnyLibrary: #('libgit2.1.0.0.dylib' 'libgit2.0.25.1.dylib')

--- a/LibGit-Core.package/LGitLibrary.class/instance/unix32LibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/unix32LibraryName.st
@@ -1,0 +1,4 @@
+accessing platform
+unix32LibraryName
+
+	^ FFIUnix32LibraryFinder findAnyLibrary: #('libgit2.so.1.0.0' 'libgit2.so.0.25.1')

--- a/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
@@ -1,0 +1,4 @@
+accessing platform
+unix64LibraryName
+
+	^ FFIUnix64LibraryFinder findAnyLibrary: #('libgit2.so.1.0.0' 'libgit2.so.0.25.1')

--- a/LibGit-Core.package/LGitLibrary.class/instance/win32LibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/win32LibraryName.st
@@ -1,0 +1,4 @@
+accessing platform
+win32LibraryName
+
+	^ FFIWindowsLibraryFinder findAnyLibrary: #('libgit2-1-0-0.dll' 'libgit2.dll')


### PR DESCRIPTION
using library finder to match libgit2 library (and rename methods to its new name).

because now with the use of OSB, we will move to use system dependencies and that and we cannot have hardcoded the library (also, using 1.0 allow us to do this change)