### PR TITLE
Add position accessor

### DIFF
--- a/LibGit-FileSystem.package/LGitReadStream.class/instance/position.st
+++ b/LibGit-FileSystem.package/LGitReadStream.class/instance/position.st
@@ -1,0 +1,4 @@
+accessing
+position
+	
+	^ position


### PR DESCRIPTION
This accessor seems missing when using Iceberg in Pharo8 image.
