### PR TITLE
LGitSignature: Answer #name and #email using  #readStringUTF8 instead…

### DIFF
--- a/LibGit-Core.package/LGitSignature.class/instance/email.st
+++ b/LibGit-Core.package/LGitSignature.class/instance/email.st
@@ -1,3 +1,3 @@
 accessing
 email
-	^ self prim_email readString
+	^ self prim_email readStringUTF8

--- a/LibGit-Core.package/LGitSignature.class/instance/name.st
+++ b/LibGit-Core.package/LGitSignature.class/instance/name.st
@@ -1,3 +1,3 @@
 accessing
 name
-	^ self prim_name readString
+	^ self prim_name readStringUTF8

--- a/LibGit-Tests.package/LGitCommitCreationTest.class/instance/testDefaultSignatureWithUTF8Strings.st
+++ b/LibGit-Tests.package/LGitCommitCreationTest.class/instance/testDefaultSignatureWithUTF8Strings.st
@@ -1,0 +1,39 @@
+tests
+testDefaultSignatureWithUTF8Strings
+	| subTree rootTree signature head signatureName signatureEmail |
+	signatureName := 'Bärt Simpsón'.
+	signatureEmail := 'bärtman@gótham.com'.
+	signature := LGitSignature
+		name: signatureName utf8Encoded asString
+		email: signatureEmail utf8Encoded asString.
+
+	"This test creates a LGitSignature that emulates how default signature
+	is read on my MacOS, and I think it can be generalizable to others.
+
+	Example:
+
+	In terminal:
+		$ git config --global user.name 'Martín Dias'
+	
+	From this test:
+		repository defaultSignature prim_name readString >>> 'MartÃ­n Dias'
+
+	BTW, the ~/.gitconfig, where git stores the global user.name, is uft8-encoded.
+	"
+
+	subTree := self createSubTreeWith: self createBlob.
+	rootTree := self createRootTreeWith: subTree.
+	(LGitCommitBuilder of: repository)
+		tree: rootTree;
+		message: 'eat my shorts';
+		parents: {};
+		updateReference: repository branches first name;
+		author: signature;
+		committer: signature;
+		writeCommit.
+
+	head := repository head object.
+	self assert: head author equals: signature.
+	self assert: head committer equals: signature.
+	self assert: head author name equals: signatureName.
+	self assert: head author email equals: signatureEmail.


### PR DESCRIPTION
This is how my global user.name is read on my MacOS, and I think it can be generalizable to others.

For example, if in terminal I set my name with tildes:
```
	$ git config --global user.name 'Martín Dias'
```	

In Pharo, I evaluate:
```
	aLGitRepository defaultSignature name.
	aLGitRepository defaultSignature prim_name readString.
```
and obtain `'MartÃ­n Dias'` in both cases.

**The solution I propose in this PR** 

The method `readString` is an extension of UnifiedFFI package, but there this also `readStringUTF8` which reads the name and email correctly. I created a test that emulates my problem and it's fixed.

**Comments**

First. I could convert the name and email with from the utf8 encoding only when reading the `LGitRepository>>defaultSignature`. 

Second. Didn't dig why, but if (in the test) I create the signature with `LGitSignature name: 'Martín Dias' email: '...'` the, there is no problem. That's why I emulate my problem creating the signature with `LGitSignature name: 'Martín Dias' utf8Encoded asString email: '...'`.

Third. Apparently, another option to create the test scenario is to update the `.git/config` file of a test repository to add the following lines:
```
[user]
	name = Bárt Sïmpsòn
```

Fouth. I checked with `flie -I ~/.gitconfig` that  git stores the global user.name with a uft8 encoding.

Fifth. I was working in a recent Pharo 9, and verified that `LGitLibrary uniqueInstance version` is `#(1 0 0)`.

