### PR TITLE
Add LGitRemote>>defaultBranchName (WIP)

### DIFF
--- a/LibGit-Core.package/LGitRemote.class/instance/defaultBranchName.st
+++ b/LibGit-Core.package/LGitRemote.class/instance/defaultBranchName.st
@@ -1,0 +1,15 @@
+accessing
+defaultBranchName
+	"Answer the name of the remote's default branch.
+	
+	Must only be called after connecting.
+	"
+
+	| buf defaultBranchName |
+	buf := LGitBuf new.
+	[	self withReturnHandlerDo: [
+			self remote_default_branch: buf ].
+		defaultBranchName := buf prim_ptr readStringUTF8.
+	] ensure: [ buf free ].
+
+	^ defaultBranchName

--- a/LibGit-Core.package/LGitRemote.class/instance/remote_connect.direction.callbacks..st
+++ b/LibGit-Core.package/LGitRemote.class/instance/remote_connect.direction.callbacks..st
@@ -1,7 +1,9 @@
 libgit-calls
 remote_connect: remote direction: direction callbacks: remoteCallbacks
 	
-	^ self
-		ffiCallSafely:
-			#(LGitReturnCodeEnum git_remote_connect #(self , LGitDirectionEnum direction , LGitRemoteCallbacks * remoteCallbacks))
-		options: #()
+	^ self ffiLibrary uniqueInstance version first = 0
+		ifTrue: [
+			self shouldBeImplemented.
+			self remote_connect_v0251: remote direction: direction callbacks: remoteCallbacks ]
+		ifFalse: [ 
+			self remote_connect_v100: remote direction: direction callbacks: remoteCallbacks ]

--- a/LibGit-Core.package/LGitRemote.class/instance/remote_connect_v100.direction.callbacks..st
+++ b/LibGit-Core.package/LGitRemote.class/instance/remote_connect_v100.direction.callbacks..st
@@ -1,0 +1,9 @@
+libgit-calls
+remote_connect_v100: remote direction: direction callbacks: remoteCallbacks
+
+	^ self
+		ffiCallSafely:
+			#(LGitReturnCodeEnum git_remote_connect #(self , LGitDirectionEnum direction , LGitRemoteCallbacksV100 * remoteCallbacks))
+		options: #()
+	
+	

--- a/LibGit-Core.package/LGitRemote.class/instance/remote_default_branch..st
+++ b/LibGit-Core.package/LGitRemote.class/instance/remote_default_branch..st
@@ -1,0 +1,13 @@
+libgit-calls
+remote_default_branch: out
+	"Retrieve the name of the remote's default branch.
+	
+	The default branch of a repository is the branch which HEAD points to. If the remote does not support reporting this information directly, it performs the guess as git does; that is, if there are multiple branches which point to the same commit, the first one is chosen. If the master branch is a candidate, it wins.
+	
+	This function must only be called after connecting.
+	
+	See: https://libgit2.org/libgit2/#v1.0.0/group/remote/git_remote_default_branch"
+
+	^ self
+		ffiCallSafely: #(LGitReturnCodeEnum git_remote_default_branch(LGitBuf *out, self))
+		options: #()


### PR DESCRIPTION
I tested it locally with this code:

```smalltalk
| aRepo aRemote |

aRepo := LGitRepository on: '/Users/tinchodias/d/iceberg-shared-repositories/iceberg' asFileReference.
aRepo open.

aRemote := LGitRemote of: aRepo named: 'pharo-vcs'.
aRemote lookup; connectFetch.
aRemote defaultBranchName. "'refs/heads/dev-1.8'"
```

## TODO:
- Add test.
- Answer a LGitBranch instead of only a `String`.
- Need to disconnect after `connectFetch`?
- Support libgit < 1.0.0?
