### PR TITLE
Do not modify byte string

### DIFF
--- a/LibGit-Tests.package/LGitDiffTest.class/instance/testDiffTreeToTree.st
+++ b/LibGit-Tests.package/LGitDiffTest.class/instance/testDiffTreeToTree.st
@@ -18,5 +18,5 @@ eat my shorts
 \ No newline at end of file
 extra textrts
 \ No newline at end of file
-' replaceAll: Character cr with: Character lf.
+' copyReplaceAll: Character cr asString with: Character lf asString.
 	self assert: (diff patchAt: diff numberOfDeltas) printDiff equals: printDiff


### PR DESCRIPTION
When I run the test they throw an error as a byte string is modified

![image](https://user-images.githubusercontent.com/5980033/104222375-7b693800-5442-11eb-9914-09a41a8e3e43.png)

the PR fixes this