### PR TITLE
change #diff_find_similar:diff_find_options: to use #ffiCallSafely:

### DIFF
--- a/LibGit-Core.package/LGitDiff.class/instance/diff_find_similar.diff_find_options..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diff_find_similar.diff_find_options..st
@@ -1,4 +1,4 @@
 libgit-calls
 diff_find_similar: diff diff_find_options: options
 	
-	^ self call: #(LGitReturnCodeEnum git_diff_find_similar #(self, LGitDiffFindOptions *options)) options: #()
+	^ self ffiCallSafely: #(LGitReturnCodeEnum git_diff_find_similar #(self, LGitDiffFindOptions *options)) options: #()


### PR DESCRIPTION
change #diff_find_similar:diff_find_options: to use #ffiCallSafely: like all the other methods

fixes https://github.com/pharo-project/pharo/issues/8128
fixes https://github.com/pharo-vcs/iceberg/issues/1398