### PR TITLE
FFICompilerPlugin-init-in-postload

### DIFF
--- a/BaselineOfLibGit.package/BaselineOfLibGit.class/instance/baseline..st
+++ b/BaselineOfLibGit.package/BaselineOfLibGit.class/instance/baseline..st
@@ -5,6 +5,7 @@ baseline: spec
     for: #(common)
     do: [ 
       spec
+		  postLoadDoIt: #'postload:package:';
     	  package: 'LibGit-FileSystem' with: [ spec requires: 'LibGit-Core' ];    
 		  package: 'LibGit-Tests' with: [ spec requires: 'LibGit-Core' ];
         package: 'LibGit-GT' with: [ spec requires: 'LibGit-Core' ];

--- a/BaselineOfLibGit.package/BaselineOfLibGit.class/instance/postload.package..st
+++ b/BaselineOfLibGit.package/BaselineOfLibGit.class/instance/postload.package..st
@@ -1,0 +1,4 @@
+actions
+postload: loader package: packageSpec
+	"we need to initialize the FFICompilerPlugin as we added methods with <ffiCalloutTranslator>"
+	FFICompilerPlugin initialize


### PR DESCRIPTION
Due to a bug report for large image recompilation being very slow, we removed the automatic mechanism of FFICompilerPlugin registering for every method compilation (and  trigger a recompilation of all ffi methods each time it sees a #ffiCalloutTranslator pragma).

Add libgit adds <ffiCalloutTranslator> methods, it needs to call the FFICompilerPlugin initialize after it gets loaded.

This PR adds a postload to do this once after loading libgit instead of many, many times on each image recompile.

fixes https://github.com/pharo-project/pharo/issues/5129


