### PR TITLE
add libgit2 1.3 

### DIFF
--- a/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
@@ -7,5 +7,6 @@ unix64LibraryName
 		'libgit2.so.1.0.0' 
 		'libgit2.so.1.0'
 		'libgit2.so.1.1'
-		'libgit2.so.1.2' 
+		'libgit2.so.1.2'
+		'libgit2.so.1.3' 
 		'libgit2.so.0.25.1')


### PR DESCRIPTION
seems to be working properly, no need to special characters, because well... this is needed already in arch distributions :)