### PR TITLE
use 'libgit2.so' name first

### DIFF
--- a/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
@@ -1,9 +1,11 @@
 accessing - platform
 unix64LibraryName
 
-	^ FFIUnix64LibraryFinder findAnyLibrary: #(
-		"This name is wrong, but some versions of the VM has this library shipped with the bad name"
+	^ FFIUnix64LibraryFinder findAnyLibrary: #(		
+		'libgit2.so'
 		'libgit2.1.0.0.so' 
+		
+		"Kept for compatibility"
 		'libgit2.so.1.0.0' 
 		'libgit2.so.1.0'
 		'libgit2.so.1.1'


### PR DESCRIPTION
Otherwise we need ad hocs links to run Pharo on Arch-based Linux.
cf. https://github.com/pharo-project/pharo/issues/9729