### PR TITLE
More robust credential callback

### DIFF
--- a/LibGit-Core.package/LGitAbstractRemoteCallbacks.class/class/newCredentialsCallbackFor..st
+++ b/LibGit-Core.package/LGitAbstractRemoteCallbacks.class/class/newCredentialsCallbackFor..st
@@ -1,11 +1,23 @@
 private
 newCredentialsCallbackFor: provider
+	
+	"Callback defined in https://github.com/libgit2/libgit2/blob/936b184e7494158c20e522981f4a324cac6ffa47/include/git2/credential.h#L131
+	
+	Fill the credentials and return
+		0 for success
+		<0 for error
+		>0 for no credentials
+	"
+
 	^ LGitCredAcquireCallback
-		on: [ :output :url :username_from_url :allowed_types :data | 
-			"Allowed types are defined in git_credtype_t 
-		https://github.com/libgit2/libgit2/blob/HEAD/include/git2/transport.h#L81-111"
-			self
+		on: [ :output :url :username_from_url :allowed_types :data | | return |
+			return := -1.
+			[return := self
 				putCredentialsType: allowed_types
 				username: username_from_url
 				provider: provider
-				onto: output ]
+				onto: output] on: Error fork: [ :error |
+					"In case of exception, return -1 and continue executing.
+					Try opening a debugger on pharo to debug the problem."
+					error pass ].
+			return ]


### PR DESCRIPTION
Catch all errors during credential obtention
If error return -1 and open a debugger in a separate thread
If not error return the value