### PR TITLE
Fix diff_stats_to_buf FFI call

### DIFF
--- a/LibGit-Core.package/LGitDiffStats.class/instance/diff_stats_to_buf.stats.format.width..st
+++ b/LibGit-Core.package/LGitDiffStats.class/instance/diff_stats_to_buf.stats.format.width..st
@@ -3,5 +3,5 @@ diff_stats_to_buf: out stats: stats format: format width: width
 	
 	^ self
 		ffiCallSafely:
-			#(LGitReturnCodeEnum git_diff_stats_to_buf #(LGitBuffer out , self , LGitDiffStatsFormatTypeEnum format , size_t width))
+			#(LGitReturnCodeEnum git_diff_stats_to_buf #(LGitBuf * out , self , LGitDiffStatsFormatTypeEnum format , size_t width))
 		options: #()


### PR DESCRIPTION
In the class LGitDiffStats, when calling the FFI function _#diff_stats_to_buf:stats:format:width:_ the function wrongly calls the non-existent class LGitBuffer.

A pointer to an object of type LGitBuf should be used instead.