### PR TITLE
Fix pathspec_match for strict mode on

### DIFF
--- a/LibGit-Core.package/LGitTree.class/instance/pathspec_match.flags..st
+++ b/LibGit-Core.package/LGitTree.class/instance/pathspec_match.flags..st
@@ -1,3 +1,11 @@
 libgit - calls
 pathspec_match: ps flags: flags
-	^ self ffiCallSafely: #(int git_pathspec_match_tree(0, self, LGitPathSpecFlagTypeEnum flags, LGitPathSpec ps))
+	"See: https://libgit2.org/libgit2/#HEAD/group/pathspec/git_pathspec_match_tree"
+
+	^ self ffiCallSafely: #(
+		int
+		git_pathspec_match_tree(
+			void* 0,
+			self,
+			LGitPathSpecFlagTypeEnum flags,
+			LGitPathSpec ps))


### PR DESCRIPTION
IIUC this is a fix

Fixes https://github.com/pharo-vcs/iceberg/issues/1811