### PR TITLE
Fix for pharo/pharo-project#16677:  libgit2 library not listed in LGitLibrary>>#unix64LibraryName

### DIFF
--- a/LibGit-Core.package/LGitLibrary.class/instance/pushOptionsStructureClass.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/pushOptionsStructureClass.st
@@ -8,5 +8,8 @@ pushOptionsStructureClass
 		ifTrue: [ ^ LGitPushOptionsV100 ].
 	(self ffiLibrary uniqueInstance isVersionLessThan: #(1 4))
 		ifTrue: [ ^ LGitPushOptionsV120 ].
+	(self ffiLibrary uniqueInstance isVersionLessThan: #(1 8))
+		ifTrue: [ ^ LGitPushOptionsV140 ].
+
+	^ LGitPushOptionsV180 
 	
-	^ LGitPushOptionsV140

--- a/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/unix64LibraryName.st
@@ -2,6 +2,7 @@ accessing - platform
 unix64LibraryName
 
 	^ FFIUnix64LibraryFinder findAnyLibrary: #(
+		'libgit2.so.1.8'
 		'libgit2.so.1.7'
 		'libgit2.so.1.6'
 		'libgit2.so.1.5'

--- a/LibGit-Core.package/LGitPushOptionsV180.class/class/fieldsDesc.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/class/fieldsDesc.st
@@ -1,0 +1,44 @@
+field definition
+fieldsDesc
+	"self rebuildFieldAccessors"
+
+	^ #(
+	LGitOptionsVersionsEnum version;
+
+	"
+	 * If the transport being used to push to the remote requires the creation
+	 * of a pack file, this controls the number of worker threads used by
+	 * the packbuilder when creating that pack file to be sent to the remote.
+	 *
+	 * If set to 0, the packbuilder will auto-detect the number of threads
+	 * to create. The default value is 1.
+	 "
+	uint pb_parallelism;
+
+	"
+	 * Callbacks to use for this push operation
+	 "
+	LGitRemoteCallbacksV120 callbacks;
+		
+	"
+	* Proxy options to use, by default no proxy is used.
+	"
+	LGitProxyOptions proxy_opts;
+
+	"
+	 * Whether to allow off-site redirects.  If this is not
+	 * specified, the `http.followRedirects` configuration setting
+	 * will be consulted.
+	"
+	LGitRemoteRedirectEnum follow_redirects;
+
+	"
+	 * Extra headers for this push operation
+	"
+	LGitStringArray custom_headers;
+	
+	"
+	 * 'Push options' to deliver to the remote.
+	"
+	LGitStringArray remote_push_options;
+)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_callbacks..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_callbacks..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_callbacks: anObject
+	"This method was automatically generated"
+	handle structAt: OFFSET_PRIM_CALLBACKS put: anObject getHandle length: LGitRemoteCallbacksV120 byteSize

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_callbacks.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_callbacks.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_callbacks
+	"This method was automatically generated"
+	^ LGitRemoteCallbacksV120 fromHandle: (handle referenceStructAt: OFFSET_PRIM_CALLBACKS length: LGitRemoteCallbacksV120 byteSize)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_custom_headers..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_custom_headers..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_custom_headers: anObject
+	"This method was automatically generated"
+	handle structAt: OFFSET_PRIM_CUSTOM_HEADERS put: anObject getHandle length: LGitStringArray byteSize

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_custom_headers.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_custom_headers.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_custom_headers
+	"This method was automatically generated"
+	^ LGitStringArray fromHandle: (handle referenceStructAt: OFFSET_PRIM_CUSTOM_HEADERS length: LGitStringArray byteSize)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_follow_redirects..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_follow_redirects..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_follow_redirects: anObject
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_PRIM_FOLLOW_REDIRECTS put: anObject value

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_follow_redirects.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_follow_redirects.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_follow_redirects
+	"This method was automatically generated"
+	^LGitRemoteRedirectEnum fromInteger: (handle unsignedLongAt: OFFSET_PRIM_FOLLOW_REDIRECTS)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_pb_parallelism..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_pb_parallelism..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_pb_parallelism: anObject
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_PRIM_PB_PARALLELISM put: anObject

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_pb_parallelism.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_pb_parallelism.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_pb_parallelism
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_PRIM_PB_PARALLELISM

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_proxy_opts..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_proxy_opts..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_proxy_opts: anObject
+	"This method was automatically generated"
+	handle structAt: OFFSET_PRIM_PROXY_OPTS put: anObject getHandle length: LGitProxyOptions byteSize

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_proxy_opts.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_proxy_opts.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_proxy_opts
+	"This method was automatically generated"
+	^ LGitProxyOptions fromHandle: (handle referenceStructAt: OFFSET_PRIM_PROXY_OPTS length: LGitProxyOptions byteSize)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_remote_push_options..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_remote_push_options..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_remote_push_options: anObject
+	"This method was automatically generated"
+	handle structAt: OFFSET_PRIM_REMOTE_PUSH_OPTIONS put: anObject getHandle length: LGitStringArray byteSize

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_remote_push_options.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_remote_push_options.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_remote_push_options
+	"This method was automatically generated"
+	^ LGitStringArray fromHandle: (handle referenceStructAt: OFFSET_PRIM_REMOTE_PUSH_OPTIONS length: LGitStringArray byteSize)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_version..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_version..st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_version: anObject
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_PRIM_VERSION put: anObject value

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_version.st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/prim_version.st
@@ -1,0 +1,4 @@
+libgit-fields
+prim_version
+	"This method was automatically generated"
+	^LGitOptionsVersionsEnum fromInteger: (handle unsignedLongAt: OFFSET_PRIM_VERSION)

--- a/LibGit-Core.package/LGitPushOptionsV180.class/instance/push_init_options.version..st
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/instance/push_init_options.version..st
@@ -1,0 +1,5 @@
+libgit - calls
+push_init_options: options version: version
+	self
+		ffiCall: #(LGitReturnCodeEnum git_push_init_options(LGitPushOptionsV180 *options, LGitOptionsVersionsEnum version))
+		options: #()

--- a/LibGit-Core.package/LGitPushOptionsV180.class/properties.json
+++ b/LibGit-Core.package/LGitPushOptionsV180.class/properties.json
@@ -1,0 +1,19 @@
+{
+	"commentStamp" : "",
+	"super" : "LGitAbstractPushOptions",
+	"category" : "LibGit-Core-FFI-Structs",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [
+		"OFFSET_PRIM_CALLBACKS",
+		"OFFSET_PRIM_CUSTOM_HEADERS",
+		"OFFSET_PRIM_FOLLOW_REDIRECTS",
+		"OFFSET_PRIM_PB_PARALLELISM",
+		"OFFSET_PRIM_PROXY_OPTS",
+		"OFFSET_PRIM_REMOTE_PUSH_OPTIONS",
+		"OFFSET_PRIM_VERSION"
+	],
+	"instvars" : [ ],
+	"name" : "LGitPushOptionsV180",
+	"type" : "normal"
+}

--- a/LibGit-Core.package/LGitRemote.class/instance/remote_push.refspecs.opts..st
+++ b/LibGit-Core.package/LGitRemote.class/instance/remote_push.refspecs.opts..st
@@ -7,5 +7,7 @@ remote_push: remote refspecs: refspecs opts: opts
 		ifTrue: [ ^ self remote_push_v100: remote refspecs: refspecs opts: opts ].
 	(self ffiLibrary uniqueInstance isVersionLessThan: #(1 4))
 		ifTrue: [ ^ self remote_push_v120: remote refspecs: refspecs opts: opts ].
+	(self ffiLibrary uniqueInstance isVersionLessThan: #(1 8))
+		ifTrue: [ ^ self remote_push_v140: remote refspecs: refspecs opts: opts ].	
 	
-	^ self remote_push_v140: remote refspecs: refspecs opts: opts
+	^ self remote_push_v180: remote refspecs: refspecs opts: opts

--- a/LibGit-Core.package/LGitRemote.class/instance/remote_push_v180.refspecs.opts..st
+++ b/LibGit-Core.package/LGitRemote.class/instance/remote_push_v180.refspecs.opts..st
@@ -1,0 +1,8 @@
+libgit - calls
+remote_push_v180: remote refspecs: refspecs opts: opts
+
+	^ self ffiCallSafely: #(LGitReturnCodeEnum git_remote_push #(
+			self, 
+			LGitStringArray *refspecs, 
+			LGitPushOptionsV180 *opts))
+		options: #(optCoerceNilToNull)


### PR DESCRIPTION
Add support for ligbit2 v1.8 that made breaking changes in the push structs

- Added LGitPushOptionsV180 with the new field description
- Updated push calls to consider v1.8 existence
- Updated unix64LibraryName to include 1.8