### PR TITLE
Reimplement #isBlob and #isLeaf on LGitTreeEntry as a comparison of the entry’s #type instead of as a delegation to its #object

### DIFF
--- a/LibGit-Core.package/LGitTreeEntry.class/instance/isBlob.st
+++ b/LibGit-Core.package/LGitTreeEntry.class/instance/isBlob.st
@@ -1,3 +1,3 @@
 testing
 isBlob
-	^ self object isBlob
+	^ self type = LGitObjectTypeEnum git_obj_blob

--- a/LibGit-Core.package/LGitTreeEntry.class/instance/isLeaf.st
+++ b/LibGit-Core.package/LGitTreeEntry.class/instance/isLeaf.st
@@ -1,4 +1,4 @@
 testing
 isLeaf
 
-	^ self object isTree
+	^ self type = LGitObjectTypeEnum git_obj_tree


### PR DESCRIPTION
This pull request reimplements #isBlob and #isLeaf on LGitTreeEntry as a comparison of the entry’s #type instead of as a delegation to its #object. The latter signals a LGit_GIT_ENOTFOUND for the kind of entries used for [git submodules](https://git-scm.com/docs/gitsubmodules) as their #objectId is the LGitId of a commit in the submodule’s repository.