### PR TITLE
Reimplement #basicIsDirectory: and #basicIsFile: on LGitCommitStore as a comparison of the LGitTree’s or LGitTreeEntry’s #type instead of as a delegation to its #object

### DIFF
--- a/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsDirectory..st
+++ b/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsDirectory..st
@@ -1,4 +1,4 @@
 abstract
 basicIsDirectory: aNode
 	
-	^ aNode object isTree
+	^ aNode type = LGitObjectTypeEnum git_obj_tree

--- a/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsFile..st
+++ b/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsFile..st
@@ -1,4 +1,4 @@
 abstract
 basicIsFile: aLGitTreeEntry 
 	
-	^ aLGitTreeEntry object isBlob
+	^ aLGitTreeEntry type = LGitObjectTypeEnum git_obj_blob


### PR DESCRIPTION
This pull request reimplements #basicIsDirectory: and #basicIsFile: on LGitCommitStore as a comparison of the LGitTree’s or LGitTreeEntry’s #type instead of as a delegation to its #object. Like in pull request #92, this takes into account that #object signals a LGit_GIT_ENOTFOUND for the kind of entries used for [git submodules](https://git-scm.com/docs/gitsubmodules) as their #objectId is the LGitId of a commit in the submodule’s repository (that is, in the embedded repository rather than in the embedding repository).