### PR TITLE
Backport reimplementation of #isBlob and #isLeaf on LGitTreeEntry as a comparison of the entry’s #type to Pharo 12

### DIFF
--- a/LibGit-Core.package/LGitTreeEntry.class/instance/isBlob.st
+++ b/LibGit-Core.package/LGitTreeEntry.class/instance/isBlob.st
@@ -1,3 +1,3 @@
 testing
 isBlob
-	^ self object isBlob
+	^ self type = LGitObjectTypeEnum git_obj_blob

--- a/LibGit-Core.package/LGitTreeEntry.class/instance/isLeaf.st
+++ b/LibGit-Core.package/LGitTreeEntry.class/instance/isLeaf.st
@@ -1,4 +1,4 @@
 testing
 isLeaf
 
-	^ self object isTree
+	^ self type = LGitObjectTypeEnum git_obj_tree


### PR DESCRIPTION
This pull request backports the changes of pull request #92 to Pharo 12.