### PR TITLE
Backport reimplementation of #basicIsDirectory: and #basicIsFile: on LGitCommitStore as a comparison of the LGitTree’s or LGitTreeEntry’s #type to Pharo 12

### DIFF
--- a/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsDirectory..st
+++ b/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsDirectory..st
@@ -1,4 +1,4 @@
 abstract
 basicIsDirectory: aNode
 	
-	^ aNode object isTree
+	^ aNode type = LGitObjectTypeEnum git_obj_tree

--- a/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsFile..st
+++ b/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsFile..st
@@ -1,4 +1,4 @@
 abstract
 basicIsFile: aLGitTreeEntry 
 	
-	^ aLGitTreeEntry object isBlob
+	^ aLGitTreeEntry type = LGitObjectTypeEnum git_obj_blob

--- a/LibGit-FileSystem.package/monticello.meta/categories.st
+++ b/LibGit-FileSystem.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'LibGit-FileSystem'!
+self packageOrganizer ensurePackage: #'LibGit-FileSystem' withTags: #()!


### PR DESCRIPTION
This pull request backports the changes of pull request #93 to Pharo 12.