### PR TITLE
fix: LGitBlob contents

### DIFF
--- a/LibGit-Core.package/LGitBlob.class/instance/contents.st
+++ b/LibGit-Core.package/LGitBlob.class/instance/contents.st
@@ -3,4 +3,4 @@ contents
 
 	^ self isBinary
 		ifTrue:  [ self binaryContents ]
-		ifFalse: [ self rawBuffer utf8StringFromCString ]
+		ifFalse: [ (self rawBuffer copyFrom: 1 to: self rawSize) utf8Decoded ]


### PR DESCRIPTION
After updating from Fedora Silverblue 40 to Fedora Silverblue 41, a problem appeared whenever I tried to clone a repository.
After a bit of debugging, we found out that the `LGitBlob`'s contents getter would return the expected result with an `s` character appended in the new line. The `contents` method has been updated to correctly decode the buffer, avoiding the extra character issue on Fedora 41.