### PR TITLE
Add giffdiff functions

### DIFF
--- a/LibGit-Core.package/LGitDiff.class/instance/diff_blobs.old_as_path.new_blob.new_as_path.options.file_cb.hunk_cb.line_cb.payload..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diff_blobs.old_as_path.new_blob.new_as_path.options.file_cb.hunk_cb.line_cb.payload..st
@@ -2,6 +2,5 @@ libgit - calls
 diff_blobs: old_blob old_as_path: old_as_path new_blob: new_blob new_as_path: new_as_path options: options file_cb: file_cb hunk_cb: hunk_cb line_cb: line_cb payload: payload
 	
 	^ self
-		ffiCallSafely:
-			#(LGitReturnCodeEnum git_diff_blobs (LGitBlob old_blob , String old_as_path , LGitBlob new_blob , String new_as_path , LGitDiffOptions *options , LGitDiffFileCallback file_cb , LGitDiffHunkCallback hunk_cb , LGitDiffLineCallback line_cb , void *payload))
+		ffiCall: #(LGitReturnCodeEnum git_diff_blobs (LGitBlob old_blob , String old_as_path , LGitBlob new_blob , String new_as_path , LGitDiffOptions *options , LGitDiffFileCallback file_cb , LGitDiffHunkCallback hunk_cb , LGitDiffLineCallback line_cb , void *payload))
 		options: #(optMayGC optCoerceNilToNull)

--- a/LibGit-Core.package/LGitDiff.class/instance/diff_buffers.old_len.old_as_path.new_buffer.new_len.new_as_path.options.file_cb.binary_cb.hunk_cb.line_cb.payload..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diff_buffers.old_len.old_as_path.new_buffer.new_len.new_as_path.options.file_cb.binary_cb.hunk_cb.line_cb.payload..st
@@ -1,0 +1,18 @@
+libgit - calls
+diff_buffers: old_buffer 
+	old_len: old_len 
+	old_as_path: old_as_path 
+	new_buffer: new_buffer 
+	new_len: new_len 
+	new_as_path: new_as_path 
+	options: options 
+	file_cb: file_cb 
+	binary_cb: binary_cb 
+	hunk_cb: hunk_cb 
+	line_cb: line_cb 
+	payload: payload
+	
+	^ self
+		ffiCall:
+			#(LGitReturnCodeEnum git_diff_buffers #(FFIVoid * old_buffer , size_t old_len , String old_as_path , void *new_buffer , size_t new_len , String new_as_path , LGitDiffOptions * options , LGitDiffFileCallback file_cb , LGitDiffBinaryCallback binary_cb , LGitDiffHunkCallback hunk_cb , LGitDiffLineCallback line_cb , void * payload))
+		options: #(optMayGC optCoerceNilToNull)

--- a/LibGit-Core.package/LGitDiff.class/instance/diff_buffers.old_len.old_as_path.new_buffer.new_len.new_as_path.options.file_cb.hunk_cb.line_cb.payload..st
+++ b/LibGit-Core.package/LGitDiff.class/instance/diff_buffers.old_len.old_as_path.new_buffer.new_len.new_as_path.options.file_cb.hunk_cb.line_cb.payload..st
@@ -1,7 +1,0 @@
-libgit - calls
-diff_buffers: old_buffer old_len: old_len old_as_path: old_as_path new_buffer: new_buffer new_len: new_len new_as_path: new_as_path options: options file_cb: file_cb hunk_cb: hunk_cb line_cb: line_cb payload: payload
-	
-	^ self
-		ffiCallSafely:
-			#(LGitReturnCodeEnum git_diff_buffers #(FFIVoid * old_buffer , size_t old_len , String old_as_path , void *new_buffer , size_t new_len , String new_as_path , LGitDiffOptions * options , LGitDiffFileCallback file_cb , LGitDiffHunkCallback hunk_cb , LGitDiffLineCallback line_cb , void * payload))
-		options: #(optMayGC optCoerceNilToNull)

--- a/LibGit-Core.package/LGitDiffLine.class/class/fieldsDesc.st
+++ b/LibGit-Core.package/LGitDiffLine.class/class/fieldsDesc.st
@@ -1,7 +1,7 @@
 fields description
 fieldsDesc
 	^#(
-	LGitDiffLineTypeEnum	  origin       "A git_diff_line_t value"
+	char   origin       "A git_diff_line_t value"
 	int    old_lineno   "Line number in old file or -1 for added line"
 	int    new_lineno   "Line number in new file or -1 for deleted line"
 	int    num_lines    "Number of newline characters in content"

--- a/LibGit-Core.package/LGitDiffLine.class/instance/prim_origin..st
+++ b/LibGit-Core.package/LGitDiffLine.class/instance/prim_origin..st
@@ -1,4 +1,4 @@
-libgit - fields
+libgit-fields
 prim_origin: anObject
 	"This method was automatically generated"
-	handle unsignedLongAt: OFFSET_PRIM_ORIGIN put: anObject value
+	handle unsignedCharAt: OFFSET_PRIM_ORIGIN put: anObject

--- a/LibGit-Core.package/LGitDiffLine.class/instance/prim_origin.st
+++ b/LibGit-Core.package/LGitDiffLine.class/instance/prim_origin.st
@@ -1,4 +1,4 @@
-libgit - fields
+libgit-fields
 prim_origin
 	"This method was automatically generated"
-	^LGitDiffLineTypeEnum fromInteger: (handle unsignedLongAt: OFFSET_PRIM_ORIGIN)
+	^handle unsignedCharAt: OFFSET_PRIM_ORIGIN

--- a/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsDirectory..st
+++ b/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsDirectory..st
@@ -1,4 +1,4 @@
 abstract
 basicIsDirectory: aNode
 	
-	^ aNode object isTree
+	^ aNode type = LGitObjectTypeEnum git_obj_tree

--- a/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsFile..st
+++ b/LibGit-FileSystem.package/LGitCommitStore.class/instance/basicIsFile..st
@@ -1,4 +1,4 @@
 abstract
 basicIsFile: aLGitTreeEntry 
 	
-	^ aLGitTreeEntry object isBlob
+	^ aLGitTreeEntry type = LGitObjectTypeEnum git_obj_blob


### PR DESCRIPTION
this allows me to make a diff compare using lib git mechanism. Is barebones but it may be used in the future to enhance some merge info.
Usage: 
```smalltalk
LGitLibrary uniqueInstance initializeLibGit2.

s1 := 'xx1
yy
zz'.
s2 := 'xx2
xy
zz'.

diff := LGitDiff basicNew.

opts := LGitDiffOptions defaults.

lines := OrderedCollection new.
lineCallback := LGitDiffLineCallback on: [ :delta :hunk :line :payload |
	lines add: { line prim_origin. line prim_new_lineno. line content }. 
	0 ].

diff 
	diff_buffers: s1 
	old_len: s1 size  
	old_as_path: 'old.st' 
	new_buffer: s2 
	new_len: s2 size 
	new_as_path: 'new.st' 
	options: opts 
	file_cb: ExternalAddress null 
	binary_cb: ExternalAddress null
	hunk_cb: ExternalAddress null
	line_cb: lineCallback 
	payload: ExternalAddress null. "a LGitReturnCodeEnum(#git_ok [0])"

lines
```

 