### PR TITLE
add WideString>>asLGitExternalString and WideSymbol>>asLGitExternalString to create an external bytes in utf-8

### DIFF
--- a/LibGit-Core.package/WideString.extension/instance/asLGitExternalString.st
+++ b/LibGit-Core.package/WideString.extension/instance/asLGitExternalString.st
@@ -1,0 +1,4 @@
+*LibGit-Core
+asLGitExternalString
+
+	^ self asUTF8Bytes asString asLGitExternalString

--- a/LibGit-Core.package/WideString.extension/properties.json
+++ b/LibGit-Core.package/WideString.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "WideString"
+}

--- a/LibGit-Core.package/WideSymbol.extension/instance/asLGitExternalString.st
+++ b/LibGit-Core.package/WideSymbol.extension/instance/asLGitExternalString.st
@@ -1,0 +1,4 @@
+*LibGit-Core
+asLGitExternalString
+
+	^ self asUTF8Bytes asString asLGitExternalString

--- a/LibGit-Core.package/WideSymbol.extension/properties.json
+++ b/LibGit-Core.package/WideSymbol.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "WideSymbol"
+}


### PR DESCRIPTION
without this patch, LibGit2 fails to commit a UTF-8 filenames because String>>asLGitExternalString assumes the receiver is a ByteString. Iceberg does not suffer this issue, but other code that directly uses LibGit2 binding may be affected.

This patch provides WideString>>asLGitExternalString that encodes the receiver into a ByteString with UTF-8 and then create an. external string using String>>asLGitExternalString.
