### PR TITLE
reset compiledSpec explicitly

### DIFF
--- a/LibGit-Core.package/LGitCallback.class/class/ffiLibraryName.st
+++ b/LibGit-Core.package/LGitCallback.class/class/ffiLibraryName.st
@@ -1,0 +1,4 @@
+library path
+ffiLibraryName
+
+	^ LGitLibrary

--- a/LibGit-Core.package/LGitCallback.class/instance/ffiLibraryName.st
+++ b/LibGit-Core.package/LGitCallback.class/instance/ffiLibraryName.st
@@ -1,0 +1,4 @@
+accessing
+ffiLibraryName
+
+	^ LGitLibrary

--- a/LibGit-Core.package/LGitCallback.class/properties.json
+++ b/LibGit-Core.package/LGitCallback.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "TorstenBergmann 6/2/2021 22:34",
+	"commentStamp" : "2026-03-19T20:36:44.468587+01:00",
 	"super" : "FFICallback",
 	"category" : "LibGit-Core-FFI-Callbacks",
 	"classinstvars" : [ ],

--- a/LibGit-Core.package/LGitCloneOptions.class/class/fieldsDesc.st
+++ b/LibGit-Core.package/LGitCloneOptions.class/class/fieldsDesc.st
@@ -1,6 +1,8 @@
 accessing
 fieldsDesc
-	^#(
+	"self rebuildFieldAccessors"
+	
+	^ #(	
 		LGitOptionsVersionsEnum version;
 		
 		"

--- a/LibGit-Core.package/LGitExternalObject.class/class/finalizeCritical..st
+++ b/LibGit-Core.package/LGitExternalObject.class/class/finalizeCritical..st
@@ -1,0 +1,5 @@
+finalization
+finalizeCritical: aBlock
+
+	FinalizeMutex ifNil: [ FinalizeMutex := Mutex new ].
+	FinalizeMutex critical: aBlock

--- a/LibGit-Core.package/LGitExternalObject.class/class/finalizeResourceData..st
+++ b/LibGit-Core.package/LGitExternalObject.class/class/finalizeResourceData..st
@@ -1,6 +1,8 @@
 finalization
 finalizeResourceData: aHandle
 	"Call the class specific free frunction if aHandle is still a valid external address."
-	aHandle isNull ifTrue: [ ^self ].
-	self perform: self freeFunctionSelector with: aHandle.
-	aHandle beNull
+	
+	self finalizeCritical: [
+		aHandle isNull ifTrue: [ ^self ].
+		self perform: self freeFunctionSelector with: aHandle.
+		aHandle beNull ]

--- a/LibGit-Core.package/LGitExternalObject.class/properties.json
+++ b/LibGit-Core.package/LGitExternalObject.class/properties.json
@@ -1,9 +1,11 @@
 {
 	"classtraitcomposition" : "TLGitPrintingTrait classTrait + TLGitCalloutTrait classTrait",
-	"classvars" : [ ],
+	"classvars" : [
+		"FinalizeMutex"
+	],
 	"instvars" : [ ],
 	"name" : "LGitExternalObject",
-	"commentStamp" : "TorstenBergmann 6/2/2021 23:18",
+	"commentStamp" : "2026-04-12T17:58:41.899084+02:00",
 	"super" : "FFIExternalObject",
 	"traitcomposition" : "TLGitPrintingTrait + TLGitCalloutTrait",
 	"type" : "normal",

--- a/LibGit-Core.package/LGitExternalStructure.class/class/finalizeCritical..st
+++ b/LibGit-Core.package/LGitExternalStructure.class/class/finalizeCritical..st
@@ -1,0 +1,4 @@
+libgit - finalization
+finalizeCritical: aBlock
+
+	LGitExternalObject finalizeCritical: aBlock

--- a/LibGit-Core.package/LGitExternalStructure.class/class/finalizeResourceData..st
+++ b/LibGit-Core.package/LGitExternalStructure.class/class/finalizeResourceData..st
@@ -1,6 +1,8 @@
 libgit - finalization
 finalizeResourceData: aHandle
 	"Call the class specific free frunction if aHandle is still a valid external address."
-	aHandle isNull ifTrue: [ ^self ].
-	self perform: self freeFunctionSelector with: aHandle.
-	aHandle beNull
+	
+	self finalizeCritical: [
+		aHandle isNull ifTrue: [ ^self ].
+		self perform: self freeFunctionSelector with: aHandle.
+		aHandle beNull ]

--- a/LibGit-Core.package/LGitExternalStructure.class/class/resetStructureIfNotIn..st
+++ b/LibGit-Core.package/LGitExternalStructure.class/class/resetStructureIfNotIn..st
@@ -1,0 +1,6 @@
+class management
+resetStructureIfNotIn: alreadyReset
+	"Reset myself by recompiling all my fields."
+
+	super resetStructureIfNotIn: alreadyReset.
+	compiledSpec := nil

--- a/LibGit-Core.package/LGitExternalStructure.class/properties.json
+++ b/LibGit-Core.package/LGitExternalStructure.class/properties.json
@@ -1,9 +1,11 @@
 {
 	"classtraitcomposition" : "TLGitCalloutTrait classTrait + TLGitPrintingTrait classTrait",
-	"classvars" : [ ],
+	"classvars" : [
+		"FinalizeMutex"
+	],
 	"instvars" : [ ],
 	"name" : "LGitExternalStructure",
-	"commentStamp" : "MaxLeske 3/1/2015 20:36",
+	"commentStamp" : "2026-05-06T18:48:10.12914+02:00",
 	"super" : "FFIExternalStructure",
 	"traitcomposition" : "TLGitCalloutTrait + TLGitPrintingTrait",
 	"type" : "normal",

--- a/LibGit-Core.package/LGitFetchOptionsV190.class/instance/prim_callbacks.st
+++ b/LibGit-Core.package/LGitFetchOptionsV190.class/instance/prim_callbacks.st
@@ -1,4 +1,4 @@
 libgit-fields
 prim_callbacks
 	"This method was automatically generated"
-	^ LGitRemoteCallbacks fromHandle: (handle referenceStructAt: OFFSET_PRIM_CALLBACKS length: LGitRemoteCallbacks byteSize)
+	^ LGitRemoteCallbacksV190 fromHandle: (handle referenceStructAt: OFFSET_PRIM_CALLBACKS length: LGitRemoteCallbacksV190 byteSize)

--- a/LibGit-Core.package/LGitIndex.class/instance/hackOwner..st
+++ b/LibGit-Core.package/LGitIndex.class/instance/hackOwner..st
@@ -4,8 +4,8 @@ hackOwner: aRepository
 	 owner (a pointer to a repository), as you would expect from the documentation. 
 	This breaks libgit encapsulation, and will probably fail if updating to a newer 
 	version, but anyway if we migrate this bug should be fixed."
-	self flag: #fixMe. "When possible :)"
-	"
+
+	self flag: #fixMe. "When possible :)" "
 	NOTE: is Smalltalk wordSize + 1 because the structure is something like: 
 	struct git_index {
 		git_refcount rc;
@@ -25,6 +25,6 @@ hackOwner: aRepository
 	
 	So we need to ensure the owner is set properly.
 	"
-	self handle 
-		pointerAt: Smalltalk wordSize + 1
-		put: repository handle
+	self getHandle 
+		pointerAt: Smalltalk wordSize + 1 
+		put: repository getHandle

--- a/LibGit-Core.package/LGitIndex.class/properties.json
+++ b/LibGit-Core.package/LGitIndex.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "TorstenBergmann 6/2/2021 22:02",
+	"commentStamp" : "2026-04-12T17:58:41.899084+02:00",
 	"super" : "LGitRepositoryObject",
 	"category" : "LibGit-Core-CoreObjects",
 	"classinstvars" : [ ],

--- a/LibGit-Core.package/LGitLibrary.class/instance/runner.st
+++ b/LibGit-Core.package/LGitLibrary.class/instance/runner.st
@@ -1,0 +1,4 @@
+accessing
+runner
+
+	^ runner ifNil: [ runner := TFWorker named: 'libgit2' ]

--- a/LibGit-Core.package/LGitLibrary.class/properties.json
+++ b/LibGit-Core.package/LGitLibrary.class/properties.json
@@ -1,12 +1,13 @@
 {
-	"commentStamp" : "TorstenBergmann 6/2/2021 23:08",
+	"commentStamp" : "2026-03-19T20:36:44.468587+01:00",
 	"super" : "FFILibrary",
 	"category" : "LibGit-Core-FFI-Handling",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"initialized"
+		"initialized",
+		"runner"
 	],
 	"name" : "LGitLibrary",
 	"type" : "normal"


### PR DESCRIPTION
because otherwise structs may keep wrong sizes